### PR TITLE
Support for Animated Values

### DIFF
--- a/src/Blur.js
+++ b/src/Blur.js
@@ -29,8 +29,8 @@ module.exports = GL.createComponent(
       children: PropTypes.any.isRequired,
       passes: PropTypes.number,
       directionForPass: PropTypes.func,
-      width: PropTypes.number,
-      height: PropTypes.number,
+      width: PropTypes.any,
+      height: PropTypes.any,
       pixelRatio: PropTypes.number
     }
   });

--- a/src/BlurV.js
+++ b/src/BlurV.js
@@ -31,8 +31,8 @@ module.exports = GL.createComponent(
       passes: PropTypes.number,
       directionForPass: PropTypes.func,
       map: PropTypes.any.isRequired,
-      width: PropTypes.number,
-      height: PropTypes.number,
+      width: PropTypes.any,
+      height: PropTypes.any,
       pixelRatio: PropTypes.number
     }
   });


### PR DESCRIPTION
Avoid warnings associated with passing this component animated values rather than numbers. I can confirm that this works with RN 0.28. 
