### PR TITLE
Different import of PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "compile": "rm -rf lib/ && babel --presets es2015,stage-1,react --source-maps -d lib src",
     "prepublish": "npm run compile"
   },
+  "dependencies": {
+    "prop-types":"^15.6.0"
+  },
   "peerDependencies": {
     "gl-react": "~2.2.0"
   },

--- a/src/Blur.js
+++ b/src/Blur.js
@@ -1,8 +1,6 @@
 const GL = require("gl-react");
 const React = require("react");
-const {
-  PropTypes
-} = React;
+import PropTypes from 'prop-types';
 const Blur1D = require("./Blur1D");
 const directionForPassDefault = require("./directionForPassDefault");
 

--- a/src/Blur1D.js
+++ b/src/Blur1D.js
@@ -1,8 +1,6 @@
 const GL = require("gl-react");
 const React = require("react");
-const {
-  PropTypes
-} = React;
+import PropTypes from 'prop-types';
 
 const shaders = GL.Shaders.create({
   blur1D: {

--- a/src/BlurV.js
+++ b/src/BlurV.js
@@ -1,8 +1,6 @@
 const GL = require("gl-react");
 const React = require("react");
-const {
-  PropTypes
-} = React;
+import PropTypes from 'prop-types';
 const BlurV1D = require("./BlurV1D");
 const directionForPassDefault = require("./directionForPassDefault");
 

--- a/src/BlurV1D.js
+++ b/src/BlurV1D.js
@@ -1,8 +1,6 @@
 const GL = require("gl-react");
 const React = require("react");
-const {
-  PropTypes
-} = React;
+import PropTypes from 'prop-types';
 
 const shaders = GL.Shaders.create({
   blur1D: {


### PR DESCRIPTION
Looks like PropTypes have been moved in a different package. This
commit contains the modified imports:
https://reactjs.org/docs/typechecking-with-proptypes.html